### PR TITLE
Integrate WaitList component with improved script loading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,8 @@ import Partners from "../components/Partners";
 import Faqs from "../components/Faqs";
 import Subscribe from "../components/Subscribe";
 import Footer from "../components/footer";
+import WaitList from "../components/WaitList";
+
 
 export default function Home() {
 
@@ -30,7 +32,8 @@ export default function Home() {
         </p>
 
         <div className="rounded-md bg-gradient-to-b from-[#610DEA] via-[#56DEDE] to-[#82FFBC] p-0.5">
-          <a
+        <WaitList />
+          {/* <a
             href="https://www.x.com/localsolana"
             target="_blank"
             rel="noopener noreferrer"
@@ -38,7 +41,7 @@ export default function Home() {
             <button className="flex w-full items-center justify-center rounded p-0.5 px-4 py-2 bg-[#0d1117] hover:bg-[#2A3033]">
               <p className="text-xs font-light text-white">COMING SOON</p>
             </button>
-          </a>
+          </a> */}
         </div>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,8 +6,10 @@ import Partners from "../components/Partners";
 import Faqs from "../components/Faqs";
 import Subscribe from "../components/Subscribe";
 import Footer from "../components/footer";
-import WaitList from "../components/WaitList";
+// import WaitList from "../components/WaitList";
+import dynamic from 'next/dynamic';
 
+const WaitList = dynamic(() => import('../components/WaitList'), { ssr: false });
 
 export default function Home() {
 

--- a/components/WaitList.tsx
+++ b/components/WaitList.tsx
@@ -1,13 +1,8 @@
 import React, { useEffect } from 'react';
+import Script from 'next/script';
 
 const WaitList = () => {
   useEffect(() => {
-    // Load the external script
-    const script = document.createElement('script');
-    script.src = 'https://prod-waitlist-widget.s3.us-east-2.amazonaws.com/getwaitlist.min.js';
-    script.async = true;
-    document.body.appendChild(script);
-
     // Load the external stylesheet
     const link = document.createElement('link');
     link.rel = 'stylesheet';
@@ -17,13 +12,18 @@ const WaitList = () => {
 
     // Cleanup function
     return () => {
-      document.body.removeChild(script);
       document.head.removeChild(link);
     };
   }, []);
 
   return (
-    <div id="getWaitlistContainer" data-waitlist_id="19781" data-widget_type="WIDGET_1"></div>
+    <>
+      <Script
+        src="https://prod-waitlist-widget.s3.us-east-2.amazonaws.com/getwaitlist.min.js"
+        strategy="lazyOnload"
+      />
+      <div id="getWaitlistContainer" data-waitlist_id="19781" data-widget_type="WIDGET_1"></div>
+    </>
   );
 };
 

--- a/components/WaitList.tsx
+++ b/components/WaitList.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+
+const WaitList = () => {
+  useEffect(() => {
+    // Load the external script
+    const script = document.createElement('script');
+    script.src = 'https://prod-waitlist-widget.s3.us-east-2.amazonaws.com/getwaitlist.min.js';
+    script.async = true;
+    document.body.appendChild(script);
+
+    // Load the external stylesheet
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href = 'https://prod-waitlist-widget.s3.us-east-2.amazonaws.com/getwaitlist.min.css';
+    document.head.appendChild(link);
+
+    // Cleanup function
+    return () => {
+      document.body.removeChild(script);
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  return (
+    <div id="getWaitlistContainer" data-waitlist_id="19781" data-widget_type="WIDGET_1"></div>
+  );
+};
+
+export default WaitList;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "LocalSolana Site",
+  "name": "localsolana-site",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "LocalSolana Site",
+      "name": "localsolana-site",
       "version": "0.1.0",
       "dependencies": {
         "next": "14.2.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LocalSolana Site",
+  "name": "localsolana-site",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This pull request integrates the WaitList component into the LocalSolana site. The key changes are:

1. Created a new `WaitList` component (`components/WaitList.tsx`) that:
   - Uses Next.js's `Script` component for controlled script loading
   - Loads the external stylesheet in a `useEffect` hook
   - Renders the wait list container div

2. Updated the `Home` component (`app/page.tsx`) to:
   - Use dynamic import for the `WaitList` component with `ssr: false`
   - Replace the "COMING SOON" button with the `WaitList` component

3. Modified `package.json` to update the project name to "localsolana-site"